### PR TITLE
added disclaimer for devices having less memory failing to generate 50k users

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ This project is open-sourced software licensed under the [GNU General Public Lic
    ```bash
    php artisan export:users
    ```
+   
+> **Note/Disclaimer**: The export command will generate multiple CSV files, each containing 10,000 users. 
+> If your pc is slow, you can reduce the number of users to be generated in the `UserSeeder.php` file.
+> I will update the command to allow the user to specify the number of users to be generated in the future.


### PR DESCRIPTION
## Description
This PR adds a disclaimer regarding potential failures when generating 50,000 users on devices with limited memory.

- **Commit:** 6111a03 (HEAD -> feat/readme-disclaimer)

The disclaimer has been included to inform users that the user generation process may not succeed on devices with less memory.
